### PR TITLE
Use libdtb to parse device tree

### DIFF
--- a/os/Makefile
+++ b/os/Makefile
@@ -30,7 +30,8 @@ OBJS = \
   $K/plic.o \
   $K/virtio_disk.o \
   $K/sbi.o \
-  $K/dtb.o
+  $K/dtb.o \
+  $K/globals.o
 
 CC=riscv64-linux-gnu-gcc
 AS=riscv64-linux-gnu-as

--- a/os/kernel/defs.h
+++ b/os/kernel/defs.h
@@ -181,6 +181,7 @@ int             plic_claim(void);
 void            plic_complete(int);
 
 // virtio_disk.c
+int             virtio_disk_probe(void);
 void            virtio_disk_init(void);
 void            virtio_disk_rw(struct buf *, int);
 void            virtio_disk_intr(void);

--- a/os/kernel/dtb.c
+++ b/os/kernel/dtb.c
@@ -1,108 +1,369 @@
 #include "dtb.h"
-#include "types.h"
-#include "riscv.h"
-#include "defs.h"
-#include "sbi.h"
 
-extern int strncmp(const char *p, const char *q, uint n);
+#define DTB_MAGIC_LE DTB_BYTESWAP32(0xd00dfeed)
 
-#define BYTESWAP32(num) ((((num)>>24)&0xff) | (((num)<<8)&0xff0000) | \
-                        (((num)>>8)&0xff00) | (((num)<<24)&0xff000000))
-
-#define BYTESWAP64(num) (BYTESWAP32(num) << 32 | BYTESWAP32((num) >> 32))
-
-#define FDT_BEGIN_NODE BYTESWAP32((uint32)0x1)
-#define FDT_END_NODE   BYTESWAP32((uint32)0x2)
-#define FDT_PROP       BYTESWAP32((uint32)0x3)
-#define FDT_NOP        BYTESWAP32((uint32)0x4)
-#define FDT_END        BYTESWAP32((uint32)0x9)
-
-uint64 ram_start = 0;
-uint64 ram_size = 0;
-
-struct fdtheader {
-    uint32 magic;
-    uint32 totalsize;
-    uint32 off_dt_struct;
-    uint32 off_dt_strings;
-    uint32 off_mem_rsvmap;
-    uint32 version;
-    uint32 last_comp_version;
-    uint32 boot_cpuid_phys;
-    uint32 size_dt_strings;
-    uint32 size_dt_struct;
-} __attribute__((packed));
-
-struct fdtreserved {
-    uint64 address;
-    uint64 size;
-};
-
-static void memory_property(char *name, uint32 *property)
+int strcmp_nodename(const char *pathpart, const char *nodename)
 {
-    if (strncmp(name, "reg", 4) == 0) {
-        uint64 *property64 = (uint64 *)property;
+    while (!(*pathpart == '\0' || *nodename == '\0')) {
+        if (*pathpart != *nodename) {
+            break;
+        }
 
-        /// NOTE: documentation of the device tree file tells us that this
-        ///       should be a pair array (first element being the start and the
-        ///       second the size). Instead, Qemu's device tree gives us garbage
-        ///       as the first value and then the start/size pair.
-        ram_start = BYTESWAP64(*(property64 + 1));
-        ram_size = BYTESWAP64(*(property64 + 2));
+        pathpart++;
+        nodename++;
+    }
+
+    if (*pathpart == '\0' && *nodename == '\0') {
+        return 0;
+    }
+
+    if (*pathpart == '\0' && *nodename == '@') {
+        return 0;
+    }
+
+    return 1;
+}
+
+static void dtb_memcpy(void *dest, void *src, dtb_u64 size)
+{
+    char *cdest = (char *)dest;
+    char *csrc = (char *)src;
+    while (size > 0) {
+        *cdest = *csrc;
+        cdest++;
+        csrc++;
+        size--;
     }
 }
 
-void dtbparse(void *fdt)
+dtb *dtb_fromptr(void *ptr)
 {
-    struct fdtheader *header = fdt;
+    dtb *devicetree = (dtb *)ptr;
 
-    if (header->magic != BYTESWAP32(0xd00dfeed)) {
-        printf("kernel(%d): wrong device tree magic number %x\n", cpuid(),
-               BYTESWAP32(header->magic));
-        return;
+    if (devicetree == DTB_NULL) {
+        return DTB_NULL;
     }
 
-    struct fdtreserved *reserved = (struct fdtreserved *)((char *)fdt +
-                                   BYTESWAP32(header->off_mem_rsvmap));
-    while (!(reserved->address == 0 && reserved->size == 0)) {
-        printf("kernel(%d): reserved zone at %lx with size %ld", cpuid(),
-               reserved->address, reserved->size);
-
-        reserved++;
+    if (devicetree->magic != DTB_MAGIC_LE) {
+        return DTB_NULL;
     }
 
-    enum {
-        DEVICE_ROOT,
-        DEVICE_MEMORY,
-        DEVICE_UNKNOWN
-    } node = DEVICE_ROOT;
+    if (devicetree->last_comp_version != DTB_BYTESWAP32(16)) {
+        return DTB_NULL;
+    }
 
-    uint32 *property = (uint32 *)((char *)fdt + BYTESWAP32(header->off_dt_struct));
-    char *strings = (char *)fdt + BYTESWAP32(header->off_dt_strings);
-    while (*property != FDT_END) {
-        if (*property == FDT_BEGIN_NODE) {
-            property++;
+    return devicetree;
+}
 
-            if (node == DEVICE_ROOT && strncmp((char *)property, "memory", 6) == 0) {
-                node = DEVICE_MEMORY;
-            }
-        } else if (*property == FDT_PROP) {
-            uint32 len = BYTESWAP32(*(property + 1));
-            uint32 str_off = BYTESWAP32(*(property + 2));
+dtb_node dtb_find(dtb *devicetree, const char *path)
+{
+    dtb_u32 *struct_block = (dtb_u32 *)((dtb_u8 *)devicetree + DTB_BYTESWAP32(devicetree->off_dt_struct));
 
-            if (node == DEVICE_MEMORY) {
-                memory_property(strings + str_off, property+1);
-            }
+    // The first block from the struct node should be a DTB_BEGIN_NODE as it should be refering to
+    // the root node of the device tree. If that is not the case we return null to signal an error.
+    if (*struct_block != DTB_BEGIN_NODE) {
+        return DTB_NULL;
+    }
 
-            property += len / sizeof(uint32) + 2;
-        } else if (*property == FDT_END_NODE) {
-            if (node == DEVICE_MEMORY) {
-                node = DEVICE_ROOT;
-            }
-        } else if (*property == FDT_NOP) {
-            property++;
+    if (strcmp_nodename(path, "/") == 0) {
+        return (dtb_node)struct_block;
+    }
+
+    // Always needs to be an absolute path.
+    if (path[0] != '/') {
+        return DTB_NULL;
+    }
+
+    char parsed_path[10][256] = {0};
+    dtb_u64 parsed_i = 0;
+    dtb_u64 path_depth = 0;
+    int i = 1;
+    while (path[i] != '\0') {
+        if (path[i] == '/') {
+            path_depth++;
+            parsed_i = 0;
+        } else {
+            parsed_path[path_depth][parsed_i] = path[i];
+            parsed_i++;
         }
 
-        property++;
+        i++;
     }
+
+    dtb_u32 *token = struct_block + 1;
+    dtb_u32 parsing_depth = 0;
+    while (*token != DTB_END) {
+        if (*token == DTB_BEGIN_NODE) {
+            token++;
+            if (strcmp_nodename(parsed_path[parsing_depth], (char *)token) == 0) {
+                if (parsing_depth == path_depth) {
+                    return (dtb_node)token - 1;
+                }
+
+                parsing_depth++;
+            } else {
+                token = dtb_next_sibling(token - 1);
+                if (token == DTB_NULL) {
+                    return DTB_NULL;
+                }
+                token--;
+            }
+        } else if (*token == DTB_PROP) {
+            dtb_u32 len = DTB_BYTESWAP32(*(token + 1));
+            token += len / sizeof(dtb_u32) + 2;
+        } else if (*token == DTB_NOP) {
+        } else if (*token == DTB_END_NODE) {
+        }
+
+        token++;
+    }
+
+    return DTB_NULL;
+}
+
+dtb_node dtb_find_next(dtb_node node, char *name)
+{
+    node = dtb_next_sibling(node);
+
+    while (node != DTB_NULL) {
+        char *nodename = dtb_node_name(node);
+
+        if (strcmp_nodename(nodename, name) == 0) {
+            return node;
+        }
+
+        node = dtb_next_sibling(node);
+    }
+
+    return DTB_NULL;
+}
+
+static dtb_node find_by_phandle_from(dtb *devicetree, dtb_node from, dtb_u32 phandle)
+{
+    dtb_foreach_child(from, child) {
+        dtb_foreach_property(child, prop) {
+            char *propname = dtb_property_name(devicetree, prop);
+            if (strcmp_nodename("phandle", propname) == 0 && dtb_property_uint32(prop) == phandle) {
+                return child;
+            }
+        }
+
+        dtb_node node = find_by_phandle_from(devicetree, child, phandle);
+        if (node != DTB_NULL) {
+            return node;
+        }
+    }
+
+    return DTB_NULL;
+}
+
+dtb_node dtb_find_by_phandle(dtb *devicetree, dtb_u32 phandle)
+{
+    dtb_node root_node = dtb_find(devicetree, "/");
+
+    return find_by_phandle_from(devicetree, root_node, phandle);
+}
+
+char *dtb_property_name(dtb *devicetree, dtb_node node)
+{
+    char *strings = (char *)devicetree + DTB_BYTESWAP32(devicetree->off_dt_strings);
+    dtb_u32 stroff = DTB_BYTESWAP32(*(node + 2));
+    return strings + stroff;
+}
+
+dtb_u32 dtb_property_uint32(dtb_property prop)
+{
+    return DTB_BYTESWAP32(*(prop + 3));
+}
+
+dtb_u64 dtb_property_uint64(dtb_property prop)
+{
+    return DTB_BYTESWAP64(*(dtb_u64 *)(prop + 3));
+}
+
+char *dtb_property_string(dtb_property prop)
+{
+    return (char *)(prop + 3);
+}
+
+char *dtb_property_array(dtb_property prop)
+{
+    return (void *)(prop + 3);
+}
+
+dtb_u32 dtb_property_length(dtb_property prop)
+{
+    return DTB_BYTESWAP32(*(prop + 1));
+}
+
+char *dtb_property_next_string(char *str)
+{
+    while (*str != '\0') {
+        str++;
+    }
+
+    return str+1;
+}
+
+dtb_property dtb_first_property(dtb_node node)
+{
+    dtb_u32 *token = dtb_next_token(node);
+    while (*token != DTB_PROP) {
+        if (*token == DTB_END || *token == DTB_BEGIN_NODE || *token == DTB_END_NODE) {
+            return DTB_NULL;
+        }
+
+        token = dtb_next_token(token);
+    }
+
+    return token;
+}
+
+dtb_property dtb_next_property(dtb_property prop)
+{
+    dtb_u32 *token = dtb_next_token(prop);
+    while (*token != DTB_PROP) {
+        if (*token == DTB_END || *token == DTB_BEGIN_NODE || *token == DTB_END_NODE) {
+            return DTB_NULL;
+        }
+
+        token = dtb_next_token(token);
+    }
+
+    return token;
+}
+
+dtb_node dtb_first_child(dtb_node node)
+{
+    dtb_u32 *token = dtb_next_token(node);
+    while (*token != DTB_BEGIN_NODE) {
+        if (*token == DTB_END || *token == DTB_END_NODE) {
+            return DTB_NULL;
+        }
+
+        token = dtb_next_token(token);
+    }
+
+    return token;
+}
+
+dtb_node dtb_next_sibling(dtb_node node)
+{
+    int depth = 0;
+    while (*node != DTB_END) {
+        if (*node == DTB_BEGIN_NODE) {
+            node++;
+            depth++;
+        } else if (*node == DTB_PROP) {
+            dtb_u32 len = DTB_BYTESWAP32(*(node + 1));
+            int len_rounding = 4 - len % 4;
+            if (len % 4 == 0) {
+                node += len / sizeof(dtb_u32) + 2;
+            } else {
+                node += (len + len_rounding) / sizeof(dtb_u32) + 2;
+            }
+        } else if (*node == DTB_NOP) {
+        } else if (*node == DTB_END_NODE) {
+            depth--;
+            if (depth <= 0) {
+                node++;
+                break;
+            }
+        }
+        node++;
+    }
+
+    while (*node != DTB_BEGIN_NODE) {
+        if (*node == DTB_END) {
+            break;
+        }
+
+        if (*node == DTB_END_NODE) {
+            return DTB_NULL;
+        }
+
+        node++;
+    }
+
+    return node;
+}
+
+dtb_u64 dtb_reg_start(dtb_u32 *reg, dtb_u8 addr_cells)
+{
+    if (addr_cells == 1) {
+        return DTB_BYTESWAP32(*reg);
+    } else {
+        dtb_u64 reg_be;
+        dtb_memcpy(&reg_be, reg, addr_cells * sizeof(dtb_u32));
+        return DTB_BYTESWAP64(reg_be);
+    }
+}
+
+dtb_u64 dtb_reg_size(dtb_u32 *reg, dtb_u8 addr_cells, dtb_u8 size_cells)
+{
+    if (size_cells == 1) {
+        return DTB_BYTESWAP32(*(reg + addr_cells));
+    } else {
+        dtb_u64 reg_be;
+        dtb_memcpy(&reg_be, reg + addr_cells, size_cells * sizeof(dtb_u32));
+        return DTB_BYTESWAP64(reg_be);
+    }
+}
+
+dtb_rsvmap_entry *dtb_first_rsvmap_entry(dtb *devicetree)
+{
+    uint8_t *dtb_ptr = (uint8_t *)devicetree;
+    dtb_rsvmap_entry *entry = (dtb_rsvmap_entry *)(dtb_ptr + DTB_BYTESWAP32(devicetree->off_mem_rsvmap));
+
+    if (entry->address == 0 && entry->size == 0) {
+        return DTB_NULL;
+    }
+
+    return entry;
+}
+
+dtb_rsvmap_entry *dtb_next_rsvmap_entry(dtb_rsvmap_entry *entry)
+{
+    entry++;
+
+    if (entry->address == 0 && entry->size == 0) {
+        return DTB_NULL;
+    }
+
+    return entry;
+}
+
+dtb_u32 *dtb_next_token(dtb_u32 *token)
+{
+    if (*token == DTB_BEGIN_NODE) {
+        token++;
+
+        char *tokenchar = (char *)token;
+        while (*tokenchar != '\0') {
+            tokenchar++;
+        }
+
+        if ((dtb_u64)tokenchar % 4 != 0) {
+            tokenchar += 4 - (dtb_u64)tokenchar % 4;
+        }
+        token = (dtb_u32 *)tokenchar;
+
+        while (*token == 0) {
+            token++;
+        }
+    } else if (*token == DTB_END_NODE) {
+        token++;
+    } else if (*token == DTB_PROP) {
+        dtb_u32 len = DTB_BYTESWAP32(*(token + 1));
+        if (len % sizeof(dtb_u32) == 0) {
+            token += len / sizeof(dtb_u32) + 3;
+        } else {
+            dtb_u32 len_rounding = 4 - (len % 4);
+            token += (len + len_rounding) / sizeof(dtb_u32) + 3;
+        }
+    } else if (*token == DTB_NOP) {
+        token++;
+    }
+
+    return token;
 }

--- a/os/kernel/dtb.h
+++ b/os/kernel/dtb.h
@@ -1,11 +1,97 @@
-#ifndef DTB_H
-#define DTB_H
+#ifndef _DTB_H
+#define _DTB_H
 
-#include "types.h"
+#include <stdint.h>
+#include <stddef.h>
+typedef uint8_t  dtb_u8;
+typedef uint32_t dtb_u32;
+typedef uint64_t dtb_u64;
+#define DTB_NULL NULL
 
-extern uint64 ram_start;
-extern uint64 ram_size;
+#define DTB_BYTESWAP32(num) ((((num)>>24)&0xff) | (((num)<<8)&0xff0000) | \
+                        (((num)>>8)&0xff00) | (((num)<<24)&0xff000000))
 
-void dtbparse(void *fdt);
+#define DTB_BYTESWAP64(num) (DTB_BYTESWAP32(num) << 32 | DTB_BYTESWAP32((num) >> 32))
 
-#endif // DTB_H
+#define DTB_BEGIN_NODE DTB_BYTESWAP32((dtb_u32)0x1)
+#define DTB_END_NODE   DTB_BYTESWAP32((dtb_u32)0x2)
+#define DTB_PROP       DTB_BYTESWAP32((dtb_u32)0x3)
+#define DTB_NOP        DTB_BYTESWAP32((dtb_u32)0x4)
+#define DTB_END        DTB_BYTESWAP32((dtb_u32)0x9)
+
+typedef struct
+{
+    dtb_u32 magic;
+    dtb_u32 totalsize;
+    dtb_u32 off_dt_struct;
+    dtb_u32 off_dt_strings;
+    dtb_u32 off_mem_rsvmap;
+    dtb_u32 version;
+    dtb_u32 last_comp_version;
+    dtb_u32 boot_cpuid_phys;
+    dtb_u32 size_dt_strings;
+    dtb_u32 size_dt_struct;
+} dtb;
+
+typedef struct __attribute__((packed))
+{
+    dtb_u64 address;
+    dtb_u64 size;
+} dtb_rsvmap_entry;
+
+typedef dtb_u32* dtb_node;
+typedef dtb_u32* dtb_property;
+
+dtb *dtb_fromptr(void *ptr);
+
+dtb_node dtb_find(dtb *devicetree, const char *path);
+
+dtb_node dtb_find_next(dtb_node node, char *name);
+
+dtb_node dtb_find_by_phandle(dtb *devicetree, dtb_u32 phandle);
+
+#define dtb_node_name(node) (char *)((dtb_u32 *)node+1)
+
+char *dtb_property_name(dtb *devicetree, dtb_node node);
+
+dtb_u32 dtb_property_uint32(dtb_property prop);
+
+dtb_u64 dtb_property_uint64(dtb_property prop);
+
+char *dtb_property_string(dtb_property prop);
+
+char *dtb_property_array(dtb_property prop);
+
+dtb_u32 dtb_property_length(dtb_property prop);
+
+char *dtb_property_next_string(char *str);
+
+#define dtb_foreach_stringlist(prop, str) for (char *str = dtb_property_string(prop); str < (char *)dtb_next_token(prop); str = dtb_property_next_string(str))
+
+#define dtb_foreach_property(node, name) for (dtb_property name = dtb_first_property(node); name != NULL; name = dtb_next_property(name))
+
+dtb_property dtb_first_property(dtb_property prop);
+
+dtb_property dtb_next_property(dtb_property prop);
+
+dtb_node dtb_first_child(dtb_node node);
+
+dtb_node dtb_next_sibling(dtb_node node);
+
+#define dtb_foreach_child(node, name) for (dtb_node name = dtb_first_child(node); name != NULL; name = dtb_next_sibling(name))
+
+#define dtb_foreach_reg(prop, addr_cells, size_cells, reg) for (dtb_u32 *reg = prop+3; reg < dtb_next_token(prop); reg += addr_cells + size_cells)
+
+dtb_u64 dtb_reg_start(dtb_u32 *reg, dtb_u8 addr_cells);
+
+dtb_u64 dtb_reg_size(dtb_u32 *reg, dtb_u8 addr_cells, dtb_u8 size_cells);
+
+dtb_rsvmap_entry *dtb_first_rsvmap_entry(dtb *devicetree);
+
+dtb_rsvmap_entry *dtb_next_rsvmap_entry(dtb_rsvmap_entry *entry);
+
+#define dtb_foreach_rsvmap_entry(dtb, entry) for (dtb_rsvmap_entry *entry = dtb_first_rsvmap_entry(dtb); entry != NULL; entry = dtb_next_rsvmap_entry(entry))
+
+dtb_u32 *dtb_next_token(dtb_u32 *token);
+
+#endif // _DTB_H

--- a/os/kernel/globals.c
+++ b/os/kernel/globals.c
@@ -5,3 +5,6 @@ uint64 uart0_irq = 0;
 
 uint64 plic = 0;
 uint64 clint = 0;
+
+uint64 virtio0 = 0;
+uint64 virtio0_irq = 0;

--- a/os/kernel/globals.c
+++ b/os/kernel/globals.c
@@ -4,3 +4,4 @@ uint64 uart0 = 0;
 uint64 uart0_irq = 0;
 
 uint64 plic = 0;
+uint64 clint = 0;

--- a/os/kernel/globals.c
+++ b/os/kernel/globals.c
@@ -2,3 +2,5 @@
 
 uint64 uart0 = 0;
 uint64 uart0_irq = 0;
+
+uint64 plic = 0;

--- a/os/kernel/globals.c
+++ b/os/kernel/globals.c
@@ -1,0 +1,4 @@
+#include "globals.h"
+
+uint64 uart0 = 0;
+uint64 uart0_irq = 0;

--- a/os/kernel/globals.h
+++ b/os/kernel/globals.h
@@ -7,5 +7,6 @@ extern uint64 uart0;
 extern uint64 uart0_irq;
 
 extern uint64 plic;
+extern uint64 clint;
 
 #endif // OS_GLOBALS_H

--- a/os/kernel/globals.h
+++ b/os/kernel/globals.h
@@ -1,0 +1,9 @@
+#ifndef OS_GLOBALS_H
+#define OS_GLOBALS_H
+
+#include "types.h"
+
+extern uint64 uart0;
+extern uint64 uart0_irq;
+
+#endif // OS_GLOBALS_H

--- a/os/kernel/globals.h
+++ b/os/kernel/globals.h
@@ -6,4 +6,6 @@
 extern uint64 uart0;
 extern uint64 uart0_irq;
 
+extern uint64 plic;
+
 #endif // OS_GLOBALS_H

--- a/os/kernel/globals.h
+++ b/os/kernel/globals.h
@@ -9,4 +9,7 @@ extern uint64 uart0_irq;
 extern uint64 plic;
 extern uint64 clint;
 
+extern uint64 virtio0;
+extern uint64 virtio0_irq;
+
 #endif // OS_GLOBALS_H

--- a/os/kernel/main.c
+++ b/os/kernel/main.c
@@ -88,6 +88,8 @@ static void dtbparse(void *fdt)
 
         if (strncmp("sifive,plic-1.0.0", compatible, 18) == 0) {
             plic = reg;
+        } else if (strncmp("sifive,clint0", compatible, 14) == 0) {
+            clint = reg;
         }
     }
 }

--- a/os/kernel/main.c
+++ b/os/kernel/main.c
@@ -8,6 +8,36 @@
 
 extern void _entry();
 
+static uint64 ram_start = 0;
+static uint64 ram_size = 0;
+
+static void dtbparse(void *fdt)
+{
+    dtb *devicetree = dtb_fromptr(fdt);
+    if (devicetree == 0) {
+        panic("dtbparse");
+    }
+
+    printf("kernel(%d): parsing device tree:\n", cpuid());
+
+    dtb_node memory_node = dtb_find(devicetree, "/memory");
+    //uint32 address_cells = DTB_ADDRESS_CELLS_DEFAULT;
+    //uint32 size_cells = DTB_SIZE_CELLS_DEFAULT;
+    dtb_foreach_property(memory_node, prop) {
+        char *propname = dtb_property_name(devicetree, prop);
+        if (strncmp("#address-cells", propname, 15) == 0) {
+            // address_cells = dtb_property_uint32(prop);
+        } else if (strncmp("#size-cells", propname, 12) == 0) {
+            // size_cells = dtb_property_uint32(prop);
+        } else if (strncmp("reg", propname, 4) == 0) {
+            uint64 *property = (uint64 *)dtb_property_array(prop);
+            ram_start = DTB_BYTESWAP64(property[0]);
+            ram_size = DTB_BYTESWAP64(property[1]);
+            printf(" · Ram starts at 0x%lx with size 0x%lx\n", ram_start, ram_size);
+        }
+    }
+}
+
 // start() jumps here in supervisor mode on all CPUs.
 void
 main(void *fdt)

--- a/os/kernel/main.c
+++ b/os/kernel/main.c
@@ -72,6 +72,24 @@ static void dtbparse(void *fdt)
         }
     }
 
+    dtb_node soc_node = dtb_find(devicetree, "/soc");
+    dtb_foreach_child(soc_node, dev_node) {
+        char *compatible = 0;
+        uint64 reg = 0;
+        dtb_foreach_property(dev_node, prop) {
+            char *propname = dtb_property_name(devicetree, prop);
+
+            if (strncmp("compatible", propname, 11) == 0) {
+                compatible = dtb_property_string(prop);
+            } else if (strncmp("reg", propname, 4) == 0) {
+                reg = dtb_property_uint64(prop);
+            }
+        }
+
+        if (strncmp("sifive,plic-1.0.0", compatible, 18) == 0) {
+            plic = reg;
+        }
+    }
 }
 
 // start() jumps here in supervisor mode on all CPUs.

--- a/os/kernel/memlayout.h
+++ b/os/kernel/memlayout.h
@@ -17,10 +17,6 @@
 // end -- start of kernel page allocation area
 // PHYSTOP -- end RAM used by the kernel
 
-// qemu puts UART registers here in physical memory.
-#define UART0 0x10000000L
-#define UART0_IRQ 10
-
 // virtio mmio interface
 #define VIRTIO0 0x10001000
 #define VIRTIO0_IRQ 1

--- a/os/kernel/memlayout.h
+++ b/os/kernel/memlayout.h
@@ -17,10 +17,6 @@
 // end -- start of kernel page allocation area
 // PHYSTOP -- end RAM used by the kernel
 
-// virtio mmio interface
-#define VIRTIO0 0x10001000
-#define VIRTIO0_IRQ 1
-
 // core local interruptor (CLINT), which contains the timer.
 #define CLINT_MTIMECMP(hartid) (clint + 0x4000 + 8*(hartid))
 #define CLINT_MTIME (clint + 0xBFF8) // cycles since boot.

--- a/os/kernel/memlayout.h
+++ b/os/kernel/memlayout.h
@@ -27,12 +27,11 @@
 #define CLINT_MTIME (CLINT + 0xBFF8) // cycles since boot.
 
 // qemu puts platform-level interrupt controller (PLIC) here.
-#define PLIC 0x0c000000L
-#define PLIC_PRIORITY (PLIC + 0x0)
-#define PLIC_PENDING (PLIC + 0x1000)
-#define PLIC_SENABLE(hart) (PLIC + 0x2080 + (hart)*0x100)
-#define PLIC_SPRIORITY(hart) (PLIC + 0x201000 + (hart)*0x2000)
-#define PLIC_SCLAIM(hart) (PLIC + 0x201004 + (hart)*0x2000)
+#define PLIC_PRIORITY (plic + 0x0)
+#define PLIC_PENDING (plic + 0x1000)
+#define PLIC_SENABLE(hart) (plic + 0x2080 + (hart)*0x100)
+#define PLIC_SPRIORITY(hart) (plic + 0x201000 + (hart)*0x2000)
+#define PLIC_SCLAIM(hart) (plic + 0x201004 + (hart)*0x2000)
 
 // the kernel expects there to be RAM
 // for use by the kernel and user pages

--- a/os/kernel/memlayout.h
+++ b/os/kernel/memlayout.h
@@ -22,9 +22,8 @@
 #define VIRTIO0_IRQ 1
 
 // core local interruptor (CLINT), which contains the timer.
-#define CLINT 0x2000000L
-#define CLINT_MTIMECMP(hartid) (CLINT + 0x4000 + 8*(hartid))
-#define CLINT_MTIME (CLINT + 0xBFF8) // cycles since boot.
+#define CLINT_MTIMECMP(hartid) (clint + 0x4000 + 8*(hartid))
+#define CLINT_MTIME (clint + 0xBFF8) // cycles since boot.
 
 // qemu puts platform-level interrupt controller (PLIC) here.
 #define PLIC_PRIORITY (plic + 0x0)

--- a/os/kernel/plic.c
+++ b/os/kernel/plic.c
@@ -1,6 +1,7 @@
 #include "types.h"
 #include "param.h"
 #include "memlayout.h"
+#include "globals.h"
 #include "riscv.h"
 #include "defs.h"
 
@@ -12,7 +13,7 @@ void
 plicinit(void)
 {
     // set desired IRQ priorities non-zero (otherwise disabled).
-    *(uint32*)(PLIC + UART0_IRQ*4) = 1;
+    *(uint32*)(PLIC + uart0_irq*4) = 1;
     *(uint32*)(PLIC + VIRTIO0_IRQ*4) = 1;
 }
 
@@ -20,10 +21,10 @@ void
 plicinithart(void)
 {
     int hart = cpuid();
-    
+
     // set enable bits for this hart's S-mode
     // for the uart and virtio disk.
-    *(uint32*)PLIC_SENABLE(hart) = (1 << UART0_IRQ) | (1 << VIRTIO0_IRQ);
+    *(uint32*)PLIC_SENABLE(hart) = (1 << uart0_irq) | (1 << VIRTIO0_IRQ);
 
     // set this hart's S-mode priority threshold to 0.
     *(uint32*)PLIC_SPRIORITY(hart) = 0;

--- a/os/kernel/plic.c
+++ b/os/kernel/plic.c
@@ -13,8 +13,8 @@ void
 plicinit(void)
 {
     // set desired IRQ priorities non-zero (otherwise disabled).
-    *(uint32*)(PLIC + uart0_irq*4) = 1;
-    *(uint32*)(PLIC + VIRTIO0_IRQ*4) = 1;
+    *(uint32*)(plic + uart0_irq*4) = 1;
+    *(uint32*)(plic + VIRTIO0_IRQ*4) = 1;
 }
 
 void

--- a/os/kernel/plic.c
+++ b/os/kernel/plic.c
@@ -14,7 +14,7 @@ plicinit(void)
 {
     // set desired IRQ priorities non-zero (otherwise disabled).
     *(uint32*)(plic + uart0_irq*4) = 1;
-    *(uint32*)(plic + VIRTIO0_IRQ*4) = 1;
+    *(uint32*)(plic + virtio0_irq*4) = 1;
 }
 
 void
@@ -24,7 +24,7 @@ plicinithart(void)
 
     // set enable bits for this hart's S-mode
     // for the uart and virtio disk.
-    *(uint32*)PLIC_SENABLE(hart) = (1 << uart0_irq) | (1 << VIRTIO0_IRQ);
+    *(uint32*)PLIC_SENABLE(hart) = (1 << uart0_irq) | (1 << virtio0_irq);
 
     // set this hart's S-mode priority threshold to 0.
     *(uint32*)PLIC_SPRIORITY(hart) = 0;

--- a/os/kernel/trap.c
+++ b/os/kernel/trap.c
@@ -190,7 +190,7 @@ devintr()
 
         if(irq == uart0_irq){
             uartintr();
-        } else if(irq == VIRTIO0_IRQ){
+        } else if(irq == virtio0_irq){
             virtio_disk_intr();
         } else if(irq){
             printf("unexpected interrupt irq=%d\n", irq);

--- a/os/kernel/trap.c
+++ b/os/kernel/trap.c
@@ -2,6 +2,7 @@
 #include "types.h"
 #include "param.h"
 #include "memlayout.h"
+#include "globals.h"
 #include "riscv.h"
 #include "spinlock.h"
 #include "proc.h"
@@ -187,7 +188,7 @@ devintr()
         // irq indicates which device interrupted.
         int irq = plic_claim();
 
-        if(irq == UART0_IRQ){
+        if(irq == uart0_irq){
             uartintr();
         } else if(irq == VIRTIO0_IRQ){
             virtio_disk_intr();

--- a/os/kernel/uart.c
+++ b/os/kernel/uart.c
@@ -5,15 +5,16 @@
 #include "types.h"
 #include "param.h"
 #include "memlayout.h"
+#include "globals.h"
 #include "riscv.h"
 #include "spinlock.h"
 #include "proc.h"
 #include "defs.h"
 
 // the UART control registers are memory-mapped
-// at address UART0. this macro returns the
+// at address uart0. this macro returns the
 // address of one of the registers.
-#define Reg(reg) ((volatile unsigned char *)(UART0 + reg))
+#define Reg(reg) ((volatile unsigned char *)(uart0 + reg))
 
 // the UART control registers.
 // some have different meanings for

--- a/os/kernel/vm.c
+++ b/os/kernel/vm.c
@@ -32,7 +32,7 @@ kvmmake(void)
     kvmmap(kpgtbl, VIRTIO0, VIRTIO0, PGSIZE, PTE_R | PTE_W);
 
     // PLIC
-    kvmmap(kpgtbl, PLIC, PLIC, 0x400000, PTE_R | PTE_W);
+    kvmmap(kpgtbl, plic, plic, 0x400000, PTE_R | PTE_W);
 
     // map kernel text executable and read-only.
     kvmmap(kpgtbl, KERNBASE, KERNBASE, (uint64)etext-KERNBASE, PTE_R | PTE_X);

--- a/os/kernel/vm.c
+++ b/os/kernel/vm.c
@@ -29,7 +29,7 @@ kvmmake(void)
     kvmmap(kpgtbl, uart0, uart0, PGSIZE, PTE_R | PTE_W);
 
     // virtio mmio disk interface
-    kvmmap(kpgtbl, VIRTIO0, VIRTIO0, PGSIZE, PTE_R | PTE_W);
+    kvmmap(kpgtbl, virtio0, virtio0, PGSIZE, PTE_R | PTE_W);
 
     // PLIC
     kvmmap(kpgtbl, plic, plic, 0x400000, PTE_R | PTE_W);

--- a/os/kernel/vm.c
+++ b/os/kernel/vm.c
@@ -1,6 +1,7 @@
 #include "param.h"
 #include "types.h"
 #include "memlayout.h"
+#include "globals.h"
 #include "elf.h"
 #include "riscv.h"
 #include "defs.h"
@@ -25,7 +26,7 @@ kvmmake(void)
     memset(kpgtbl, 0, PGSIZE);
 
     // uart registers
-    kvmmap(kpgtbl, UART0, UART0, PGSIZE, PTE_R | PTE_W);
+    kvmmap(kpgtbl, uart0, uart0, PGSIZE, PTE_R | PTE_W);
 
     // virtio mmio disk interface
     kvmmap(kpgtbl, VIRTIO0, VIRTIO0, PGSIZE, PTE_R | PTE_W);


### PR DESCRIPTION
Use the [libdtb](https://github.com/IkerGalardi/libdtb) to parse the device tree for memory and supported devices.

Closes #12 