### PR TITLE
Enable landing pads on user processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ QEMUOPTS  = -machine virt -bios firmware/build/platform/generic/firmware/fw_dyna
 QEMUOPTS += -m 128M -smp 4 -nographic -global virtio-mmio.force-legacy=false
 QEMUOPTS += -drive file=fs.img,if=none,format=raw,id=x0
 QEMUOPTS += -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
+QEMUOPTS += -cpu rv64,zicfilp=true
 
 qemu: $(RESULTS)
 	qemu-system-riscv64 $(QEMUOPTS)

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ CFLAGS += -fno-builtin-memmove -fno-builtin-memcmp -fno-builtin-log -fno-builtin
 CFLAGS += -fno-builtin-strchr -fno-builtin-exit -fno-builtin-malloc -fno-builtin-putc
 CFLAGS += -fno-builtin-free -fno-builtin-memcpy -Wno-main -fno-stack-protector
 CFLAGS += -fno-builtin-printf -fno-builtin-fprintf -fno-builtin-vprintf
-CFLAGS += -I.
+CFLAGS += -I. -menable-experimental-extensions -march=rv64gc_zicfilp1p0
 
 kernel/kernel: $(OBJS) kernel/kernel.ld
 	@echo "LD      kernel/kernel"

--- a/kernel/fs.h
+++ b/kernel/fs.h
@@ -24,7 +24,7 @@ struct superblock {
 
 #define FSMAGIC 0x10203040
 
-#define NDIRECT 28
+#define NDIRECT 60
 #define NINDIRECT (BSIZE / sizeof(uint))
 #define MAXFILE (NDIRECT + NINDIRECT)
 

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -170,6 +170,11 @@ kmain(void *fdt)
                 cpuid());
     }
 
+    uint64 senvcfg = r_senvcfg();
+    senvcfg |= 1 << 2;
+    w_senvcfg(senvcfg);
+    printf("kernel(%d): enabled landing pads for user mode\n", cpuid());
+
     // ask for clock interrupts.
     sbi_set_timer(r_time() + 1000000);
 
@@ -185,6 +190,11 @@ void kmain_secondary()
     printf("kernel(%d): traps initialized\n", cpuid());
     plicinithart();     // ask PLIC for device interrupts
     printf("kernel(%d): local interrupt controller initialized\n", cpuid());
+
+    uint64 senvcfg = r_senvcfg();
+    senvcfg |= 1 << 2;
+    w_senvcfg(senvcfg);
+    printf("kernel(%d): enabled landing pads for user mode\n", cpuid());
 
     // ask for clock interrupts.
     sbi_set_timer(r_time() + 1000000);

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -131,6 +131,7 @@ found:
         release(&p->lock);
         return 0;
     }
+    p->trapframe->pelp = 0;
 
     // An empty user page table.
     p->pagetable = proc_pagetable(p);

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -77,6 +77,7 @@ struct trapframe {
     /* 264 */ uint64 t4;
     /* 272 */ uint64 t5;
     /* 280 */ uint64 t6;
+    /* 288 */ uint64 pelp;
 };
 
 enum procstate { UNUSED, USED, SLEEPING, RUNNABLE, RUNNING, ZOMBIE };

--- a/kernel/riscv.h
+++ b/kernel/riscv.h
@@ -72,6 +72,21 @@ r_sepc()
     return x;
 }
 
+// Userspace environment configuration registers.
+static inline void
+w_senvcfg(uint64 x)
+{
+    asm volatile("csrw senvcfg, %0" : : "r" (x));
+}
+
+static inline uint64
+r_senvcfg()
+{
+    uint64 x;
+    asm volatile("csrr %0, senvcfg" : "=r" (x) );
+    return x;
+}
+
 // Supervisor Trap-Vector Base Address
 // low two bits are mode.
 static inline void 


### PR DESCRIPTION
This pull request enables landing pads for user processes.

Landing pads are enabled using the `senvcfg.ELP` bit and the `sstatus.SPELP` bit is preserved for user processes.