### PR TITLE
Software based shadow stack for userspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ OBJS = kernel/entry.o \
        kernel/dtb.o \
        kernel/globals.o
 
-CFLAGS  = -Wall -Werror -O -fno-omit-frame-pointer -ggdb -gdwarf-2
+CFLAGS  = -Wall -Werror -O0 -fno-omit-frame-pointer -ggdb -gdwarf-2
 CFLAGS += -MD -mcmodel=medany -fno-common -nostdlib -mno-relax
 CFLAGS += -fno-builtin-strncpy -fno-builtin-strncmp -fno-builtin-strlen -fno-builtin-memset
 CFLAGS += -fno-builtin-memmove -fno-builtin-memcmp -fno-builtin-log -fno-builtin-bzero

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ ifeq ($(CONFIG_USER_LANDING_PAD), enabled)
 	MARCH_LP=_zicfilp1p0
 endif
 
+ifeq ($(CONFIG_USER_SHADOW_STACK), software)
+	DEFINES+=-DCONFIG_USER_SHADOW_STACK_SOFTWARE
+endif
+
 ifeq ($(CONFIG_USER_SHADOW_STACK), hardware)
 	DEFINES+=-DCONFIG_USER_SHADOW_STACK_HARDWARE
 	MARCH_SS=_zicfiss1p0
@@ -79,6 +83,9 @@ CFLAGS += $(DEFINES)
 CFLAGS_USER_EXTRA=
 ifeq ($(CONFIG_USER_SHADOW_STACK), hardware)
 	CFLAGS_USER_EXTRA=-fsanitize=shadow-call-stack -fcf-protection=return
+endif
+ifeq ($(CONFIG_USER_SHADOW_STACK), software)
+	CFLAGS_USER_EXTRA=-fsanitize=shadow-call-stack
 endif
 
 kernel/kernel: $(OBJS) kernel/kernel.ld

--- a/check.mk
+++ b/check.mk
@@ -5,7 +5,9 @@ endif
 endif
 
 ifneq ($(CONFIG_USER_SHADOW_STACK), disabled)
+ifneq ($(CONFIG_USER_SHADOW_STACK), software)
 ifneq ($(CONFIG_USER_SHADOW_STACK), hardware)
-$(error "Wrong value for CONFIG_USER_SHADOW_STACK, should be either 'enabled' or 'hardware'")
+$(error "Wrong value for CONFIG_USER_SHADOW_STACK, should be either 'enabled', 'software' or 'hardware'")
+endif
 endif
 endif

--- a/config.mk
+++ b/config.mk
@@ -7,5 +7,6 @@ CONFIG_USER_LANDING_PAD=enabled
 # Wether or not to enable shadow stack sanitization
 # Possible values:
 #   disabled: shadow stack is disabled
+#   software: software based shadow stack
 #   hardware: shadow stack using hardware extensions
 CONFIG_USER_SHADOW_STACK=hardware

--- a/user/ulib.c
+++ b/user/ulib.c
@@ -14,15 +14,15 @@ void
 #ifdef CONFIG_USER_SHADOW_STACK_SOFTWARE
 __attribute__((no_sanitize("shadow-call-stack")))
 #endif // CONFIG_USER_SHADOW_STACK_SOFTWARE
-_main()
+_main(int argc, char *argv[])
 {
-    extern int main();
+    extern int main(int argc, char *argv[]);
 
 #ifdef CONFIG_USER_SHADOW_STACK_SOFTWARE
     asm volatile("mv x3, %0" : : "r" (ss_buffer));
 #endif // CONFIG_USER_SHADOW_STACK_SOFTWARE
 
-    main();
+    main(argc, argv);
     exit(0);
 }
 

--- a/user/ulib.c
+++ b/user/ulib.c
@@ -3,13 +3,25 @@
 #include "kernel/fcntl.h"
 #include "user/user.h"
 
+#ifdef CONFIG_USER_SHADOW_STACK_SOFTWARE
+uint64 ss_buffer[256];
+#endif // CONFIG_USER_SHADOW_STACK_SOFTWARE
+
 //
 // wrapper so that it's OK if main() does not call exit().
 //
 void
+#ifdef CONFIG_USER_SHADOW_STACK_SOFTWARE
+__attribute__((no_sanitize("shadow-call-stack")))
+#endif // CONFIG_USER_SHADOW_STACK_SOFTWARE
 _main()
 {
     extern int main();
+
+#ifdef CONFIG_USER_SHADOW_STACK_SOFTWARE
+    asm volatile("mv x3, %0" : : "r" (ss_buffer));
+#endif // CONFIG_USER_SHADOW_STACK_SOFTWARE
+
     main();
     exit(0);
 }


### PR DESCRIPTION
Adds a software based shadow stack implementation for userspace programs. Pretty useless when hardware based shadow stack exists, but as those extensions are pretty new, the software based solution could help while hardware extensions arrive to chips.

Uses clang's implementation, which uses the `gp` (`x3`) register to hold the pointer to the shadow stack. The runtime uses a statically allocated buffer.

This PR also disables optimizations for both the kernel and userspace as due to probably undefined behavior certain commands like `ls` don't work (parameters to functions are not properly passed).